### PR TITLE
Keyvault refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8311,6 +8311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
+name = "roots"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "clap",
+ "ed25519 2.2.3",
+ "fangorn",
+ "flume",
+ "iroh",
+ "n0-future 0.1.3",
+ "rust-vault",
+ "secrecy 0.10.3",
+ "silent-threshold-encryption",
+ "sp-core 38.1.0",
+ "tokio",
+]
+
+[[package]]
 name = "rust-vault"
 version = "0.1.0"
 source = "git+https://github.com/colemanirby/rust-vault.git?branch=main#e83718f99ce4f81e29e9a2a39c255217925b43b7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 [workspace]
 resolver = "2"
 
-members = ["fangorn", "quickbeam", 
+members = ["fangorn", "quickbeam", "roots",
 # "entmoot", 
 "contract/predicate-registry", "contract/pool", "contract/psp22"]
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,13 +17,13 @@ This library is built with subxt and requires that you generate the proper metad
 4. Then, from the project root, generate metadata with `subxt metadata --url ws://localhost:9944 > metadata.scale`
 5. Tear down the contracts node, then build the binaries. From the root, run: `cargo build`.
 6. For Fangorn nodes to work, they currently expect for an sr25519 entry to already exist in tmp/keystore. When running your own node, you can control the name of the entry, the password for the entry, and the password for the vault. However, if using the start instances script the nodes expect very specific configurations.
-`./target/debug/quickbeam keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_0 --password substrate_password_0 -p polkadot`
+`./target/debug/roots keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_0 --password substrate_password_0 -p polkadot`
 and
-`./target/debug/quickbeam keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_1 --password substrate_password_1 -p polkadot`.
+`./target/debug/roots keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_1 --password substrate_password_1 -p polkadot`.
 This will set up the keys for the two listening nodes that will verify witnesses and provide partial decryptions. Be sure to create keys
 for the nodes that requesting for encryption and decryption
-`./target/debug/quickbeam keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_2 --password substrate_password_2 -p polkadot`
-`./target/debug/quickbeam keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_3 --password substrate_password_3 -p polkadot`
+`./target/debug/roots keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_2 --password substrate_password_2 -p polkadot`
+`./target/debug/roots keygen-pswd --keystore-dir tmp/keystore --key-name sr25519_idx_3 --password substrate_password_3 -p polkadot`
 Be sure to copy the mnemonic that is printed to the terminal in order to reproduce the keypairs later if needed.
 
 ### Build a Network
@@ -94,26 +94,26 @@ of sr25519, ed25519. (Support can be added for bls12-381 as well.)
 
 ##### Generate a new keypair
 ``` sh
-./target/debug/quickbeam keygen --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD> --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --print-mnemonic
+./target/debug/roots keygen --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD> --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --print-mnemonic
 ```
 Note: Index is only required when generating Fangorn keys and print-mnemonic is only used for sr25519 keys. Fangorn keys will be overwritten if pointing to the same vault and if they use the same naming scheme used by Fangorn on startup.
 
 #### Inspect keys
 
 ``` sh
-./target/debug/quickbeam inspect --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX>
+./target/debug/roots inspect --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX>
 ```
 
 #### Sign a Message (nonce)
 
 ``` sh
-./target/debug/quickbeam sign --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --nonce <NONCE>
+./target/debug/roots sign --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --nonce <NONCE>
 ```
 
 #### Verify a Signature (nonce)
 
 ``` sh
-./target/debug/quickbeam sign --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --signature-hex <SIGNATURE_HEX> --index <INDEX> --nonce <NONCE>
+./target/debug/roots verify --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --signature-hex <SIGNATURE_HEX> --index <INDEX> --nonce <NONCE>
 ```
 
 ### Predicate-Locked Data with Quickbeam

--- a/fangorn/src/backend/substrate.rs
+++ b/fangorn/src/backend/substrate.rs
@@ -8,7 +8,6 @@ use super::Backend;
 use anyhow::Result;
 use async_trait::async_trait;
 use rust_vault::Vault;
-use secrecy::SecretString;
 use subxt::{
     OnlineClient, PolkadotConfig,
     config::polkadot::AccountId32,
@@ -49,9 +48,7 @@ impl Signer<PolkadotConfig> for PolkadotSigner {
         let signature = self
             .sr25519_vault
             .sign(
-                String::new(),
                 signer_payload,
-                &mut SecretString::new(String::new().into_boxed_str()),
             )
             .unwrap();
         MultiSignature::Sr25519(signature.into())

--- a/fangorn/src/backend/substrate.rs
+++ b/fangorn/src/backend/substrate.rs
@@ -29,10 +29,7 @@ impl PolkadotSigner {
     pub fn new(sr25519_vault: Sr25519KeyVault) -> Self {
         let account_id = AccountId32(
             sr25519_vault
-                .get_public_key(
-                    String::from(""),
-                    &mut SecretString::new(String::from("").into_boxed_str()),
-                )
+                .get_public_key()
                 .unwrap()
                 .into(),
         );

--- a/fangorn/src/client/node.rs
+++ b/fangorn/src/client/node.rs
@@ -17,25 +17,15 @@ use iroh::{
 use iroh_blobs::{store::mem::MemStore, BlobsProtocol, ALPN as BLOBS_ALPN};
 use iroh_docs::{protocol::Docs, ALPN as DOCS_ALPN};
 use iroh_gossip::{net::Gossip, ALPN as GOSSIP_ALPN};
-use rust_vault::Vault;
-use secrecy::SecretString;
 
 use crate::{
-    crypto::keyvault::{
-        IrohKeyVault, 
-        KeyVault, 
-        KeyVaultError, 
-        Sr25519KeyVault, 
-        SteKeyVault
-    },
     pool::pool::RawPartialDecryptionMessage,
 };
 use crate::{pool::pool::PartialDecryptionMessage, types::*};
 use ark_ec::pairing::Pairing;
 use codec::Decode;
 use silent_threshold_encryption::setup::PartialDecryption;
-use silent_threshold_encryption::setup::PublicKey;
-use std::{fs::OpenOptions, io::Write};
+
 use std::{
     net::{Ipv4Addr, SocketAddrV4},
     sync::Arc,

--- a/fangorn/src/crypto/keyvault.rs
+++ b/fangorn/src/crypto/keyvault.rs
@@ -72,6 +72,8 @@ pub trait KeyVault {
 
     /// Verify a signature (can be static since verification only needs the public key)
     fn verify(public: &Self::Public, message: &[u8], signature: &Self::Signature) -> bool;
+
+    fn get_secure_password(password_name: String) -> Result<SecretString, KeyVaultError>;
 }
 
 #[derive(Clone, Debug)]
@@ -253,6 +255,9 @@ impl KeyVault for Sr25519KeyVault {
 
     fn verify(public: &Self::Public, message: &[u8], signature: &Self::Signature) -> bool {
         Self::Pair::verify(signature, message, public)
+    }
+    fn get_secure_password(_password_name: String) -> Result<SecretString, KeyVaultError> {
+        Err(KeyVaultError::Keystore(String::from("This function is not yet implemented")))
     }
 }
 #[derive(Clone, Debug)]
@@ -471,6 +476,10 @@ impl KeyVault for IrohKeyVault {
 
     fn verify(public: &Self::Public, message: &[u8], signature: &Self::Signature) -> bool {
         public.verify(message, signature).is_ok()
+    }
+    
+    fn get_secure_password(_password_name: String) -> Result<SecretString, KeyVaultError> {
+        Err(KeyVaultError::Keystore(String::from("This function is not yet implemented")))
     }
 }
 

--- a/fangorn/src/node/node.rs
+++ b/fangorn/src/node/node.rs
@@ -104,7 +104,7 @@ impl<C: Pairing> Node<C> {
                 MdnsDiscovery::builder()
                     .build(
                         iroh_vault
-                            .get_public_key(key_name, &mut file_password)
+                            .get_public_key()
                             .unwrap(),
                     )
                     .unwrap(),

--- a/fangorn/src/node/node.rs
+++ b/fangorn/src/node/node.rs
@@ -84,20 +84,14 @@ impl<C: Pairing> Node<C> {
         println!("Building the node...");
         let (iroh_vault, ste_vault) = create_vaults::<C>(vault_config.clone(), index).unwrap();
 
-        // TODO: currently key_name is not used and is managed by the vault instance itself. However, this may change in the future.
-        let key_name = String::from("");
-        // TODO: file_password should never be hard coded within an application. Currently, we always pass this in via the command line.
-        // therefore this field is not actually used. See IrohKeyVault::generate_key or SteKeyVault::generate_key
-        let mut file_password = SecretString::new(String::from("").into_boxed_str());
-
         iroh_vault
             .generate_key()
             .unwrap();
-        ste_vault.generate_key(index).unwrap();
+        ste_vault.generate_key().unwrap();
         let endpoint = Endpoint::builder()
             .secret_key(
                 iroh_vault
-                    .get_secret_key(key_name.clone(), &mut file_password)
+                    .get_secret_key()
                     .unwrap(),
             )
             .discovery(

--- a/fangorn/src/node/node.rs
+++ b/fangorn/src/node/node.rs
@@ -91,7 +91,7 @@ impl<C: Pairing> Node<C> {
         let mut file_password = SecretString::new(String::from("").into_boxed_str());
 
         iroh_vault
-            .generate_key(key_name.clone(), &mut file_password)
+            .generate_key()
             .unwrap();
         ste_vault.generate_key(index).unwrap();
         let endpoint = Endpoint::builder()

--- a/fangorn/src/node/node.rs
+++ b/fangorn/src/node/node.rs
@@ -84,10 +84,11 @@ impl<C: Pairing> Node<C> {
         println!("Building the node...");
         let (iroh_vault, ste_vault) = create_vaults::<C>(vault_config.clone(), index).unwrap();
 
-        iroh_vault
-            .generate_key()
-            .unwrap();
+        // Generate new keys on startup. May be fine for Iroh, but may want to have STE keys avaialable
+        // before startup.
+        iroh_vault.generate_key().unwrap();
         ste_vault.generate_key().unwrap();
+
         let endpoint = Endpoint::builder()
             .secret_key(
                 iroh_vault

--- a/quickbeam/README.md
+++ b/quickbeam/README.md
@@ -1,13 +1,10 @@
 # Quickbeam
 
-`quickbeam` is a command-line interface tool built using **Rust** and the **Fangorn** library. It provides utilities for key management, cryptographic signing, and encrypted file handling (encryption and decryption) leveraging the features of the Fangorn framework.
+`quickbeam` is a command-line interface tool built using **Rust** and the **Fangorn** library. It provides encrypted file handling (encryption and decryption) leveraging the features of the Fangorn framework.
 
 -----
 
 ## Features
-
-  * **Key Management:** Generate and inspect SR25519 cryptographic keys stored in a local keystore.
-  * **Cryptographic Signing:** Sign arbitrary data (currently a nonce) using a key from the local keystore.
   * **File Encryption (`Encrypt`):** Encrypt a message file under a specified 'intent' (policy) and register it.
   * **File Decryption (`Decrypt`):** Request and perform decryption of an encrypted file using a cryptographic 'witness' that satisfies the original intent.
 
@@ -15,7 +12,7 @@
 
 ## 🛠️ Usage
 
-The application is structured around several subcommands. Use `--help` on the main command or any subcommand for detailed usage information.
+Use `--help` on the main command or any subcommand for detailed usage information.
 
 ### Installation
 
@@ -29,33 +26,6 @@ git clone <repository-url>
 cd quickbeam
 cargo build --release
 # The executable will be available at target/release/quickbeam
-```
-
-### Key Management Commands
-
-#### Key Generation
-
-Generates a new SR25519 key and saves it to the specified keystore directory.
-
-```bash
-quickbeam keygen --keystore-dir /path/to/keystore
-```
-
-#### Key Inspection
-
-Lists the keys (as SS58 addresses) currently stored in the specified keystore directory.
-
-```bash
-quickbeam inspect --keystore-dir /path/to/keystore
-```
-
-#### Signing
-
-Signs a specified 32-bit nonce using the first key found in the keystore.
-
-```bash
-quickbeam sign --keystore-dir /path/to/keystore --nonce 12345
-```
 
 ### Encryption and Decryption Commands
 

--- a/quickbeam/src/main.rs
+++ b/quickbeam/src/main.rs
@@ -244,7 +244,7 @@ async fn main() -> Result<()> {
             let vault = Vault::open_or_create(keystore_dir, &mut vault_password).unwrap();
             match store_type {
                 StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new(vault);
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
                     // create sr25519 identity
                     if *print_mnemonic {
                         let public_key = keyvault
@@ -263,7 +263,7 @@ async fn main() -> Result<()> {
                 }
                 StoreType::Fangorn => {
                     // create ed25519 identity
-                    let keyvault = IrohKeyVault::new(vault, index.unwrap_or(0));
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let public_key = keyvault
                         .generate_key(key_name.clone(), &mut deref_key_password)
                         .unwrap();
@@ -279,21 +279,20 @@ async fn main() -> Result<()> {
             store_type,
             index,
         }) => {
-            let mut deref_key_password = key_password.to_owned();
             let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
             let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
             match store_type {
                 StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new(vault);
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
                     let public_key = keyvault
-                        .get_public_key(key_name.clone(), &mut deref_key_password)
+                        .get_public_key()
                         .unwrap();
                     println!("read keypair. Pubkey: {:?}", public_key)
                 }
                 StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new(vault, index.unwrap_or(0));
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let public_key = keyvault
-                        .get_public_key(key_name.clone(), &mut deref_key_password)
+                        .get_public_key()
                         .unwrap();
                     println!("read keypair. Pubkey: {:?}", public_key)
                 }
@@ -313,7 +312,7 @@ async fn main() -> Result<()> {
             let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
             match store_type {
                 StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new(vault);
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
                     let message_bytes = nonce.to_le_bytes();
                     let signature = keyvault
                         .sign(key_name.clone(), &message_bytes, &mut deref_key_password)
@@ -325,7 +324,7 @@ async fn main() -> Result<()> {
                     );
                 }
                 StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new(vault, index.unwrap_or(0));
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let message_bytes = nonce.to_le_bytes();
                     let signature = keyvault
                         .sign(key_name.clone(), &message_bytes, &mut deref_key_password)
@@ -348,14 +347,13 @@ async fn main() -> Result<()> {
             index,
             nonce,
         }) => {
-            let mut deref_key_password = key_password.to_owned();
             let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
             let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
             match store_type {
                 StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new(vault);
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
                     let public_key = keyvault
-                        .get_public_key(key_name.clone(), &mut deref_key_password)
+                        .get_public_key()
                         .unwrap();
                     let message_bytes = nonce.to_le_bytes();
                     let sig_vec = from_hex(&signature_hex).unwrap();
@@ -364,9 +362,9 @@ async fn main() -> Result<()> {
                     println!("Was sig verified: {:?}", result);
                 }
                 StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new(vault, index.unwrap_or(0));
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let public_key = keyvault
-                        .get_public_key(key_name.clone(), &mut deref_key_password)
+                        .get_public_key()
                         .unwrap();
                     let message_bytes = nonce.to_le_bytes();
                     let sig_vec = from_hex(&signature_hex).unwrap();

--- a/quickbeam/src/main.rs
+++ b/quickbeam/src/main.rs
@@ -238,9 +238,7 @@ async fn main() -> Result<()> {
             index,
             print_mnemonic,
         }) => {
-            let mut deref_key_password = key_password.to_owned();
             let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
-            SecretString::new(String::from("vault_password").into_boxed_str());
             let vault = Vault::open_or_create(keystore_dir, &mut vault_password).unwrap();
             match store_type {
                 StoreType::Polkadot => {
@@ -307,7 +305,6 @@ async fn main() -> Result<()> {
             index,
             nonce,
         }) => {
-            let mut deref_key_password = key_password.to_owned();
             let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
             let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
             match store_type {
@@ -315,7 +312,7 @@ async fn main() -> Result<()> {
                     let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
                     let message_bytes = nonce.to_le_bytes();
                     let signature = keyvault
-                        .sign(key_name.clone(), &message_bytes, &mut deref_key_password)
+                        .sign(&message_bytes)
                         .unwrap();
                     let sig_hex = to_hex(&signature.as_bytes_ref(), false);
                     println!(
@@ -327,7 +324,7 @@ async fn main() -> Result<()> {
                     let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let message_bytes = nonce.to_le_bytes();
                     let signature = keyvault
-                        .sign(key_name.clone(), &message_bytes, &mut deref_key_password)
+                        .sign(&message_bytes)
                         .unwrap();
                     let sig_hex = to_hex(&signature.to_bytes(), false);
                     println!(

--- a/quickbeam/src/main.rs
+++ b/quickbeam/src/main.rs
@@ -248,7 +248,7 @@ async fn main() -> Result<()> {
                     // create sr25519 identity
                     if *print_mnemonic {
                         let public_key = keyvault
-                            .generate_key_print_mnemonic(key_name.clone(), &mut deref_key_password)
+                            .generate_key_print_mnemonic()
                             .unwrap();
                         println!(
                             "Printned mnemonic and generated new keypair. PubKey: {:?}",
@@ -256,7 +256,7 @@ async fn main() -> Result<()> {
                         );
                     } else {
                         let public_key = keyvault
-                            .generate_key(key_name.clone(), &mut deref_key_password)
+                            .generate_key()
                             .unwrap();
                         println!("generated new keypair. PubKey: {:?}", public_key);
                     }
@@ -265,7 +265,7 @@ async fn main() -> Result<()> {
                     // create ed25519 identity
                     let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
                     let public_key = keyvault
-                        .generate_key(key_name.clone(), &mut deref_key_password)
+                        .generate_key()
                         .unwrap();
                     println!("generated new keypair. Pubkey: {:?}", public_key)
                 }

--- a/quickbeam/src/main.rs
+++ b/quickbeam/src/main.rs
@@ -1,20 +1,11 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use fangorn::{
     crypto::{
         cipher::{handle_decrypt, handle_encrypt},
-        keyvault::{IrohKeyVault, KeyVault, Sr25519KeyVault},
     },
 };
-use rust_vault::Vault;
 use secrecy::SecretString;
-use sp_core::{
-    ByteArray,
-    bytes::{from_hex, to_hex},
-    hexdisplay::AsBytesRef,
-    sr25519::Signature as SrSignature,
-};
-// use sp_core::crypto::{ExposeSecret, SecretString};
 use ark_serialize::CanonicalDeserialize;
 use fangorn::{Node, types::*};
 use iroh::{EndpointAddr, PublicKey as IrohPublicKey};
@@ -33,113 +24,9 @@ struct Cli {
     command: Option<Commands>,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
-enum StoreType {
-    Polkadot,
-    Fangorn,
-}
-
 /// Define available subcommands
 #[derive(Subcommand, Debug)]
 enum Commands {
-    Keygen {
-        /// the keystore directory
-        #[arg(long)]
-        keystore_dir: String,
-
-        #[arg(long)]
-        key_name: String,
-
-        #[arg(long, default_value = "vault_password")]
-        vault_pswd: String,
-
-        /// the password to encrypt the key with
-        #[arg(long)]
-        key_password: SecretString,
-
-        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
-        #[arg(value_enum)]
-        store_type: StoreType,
-
-        /// Index used for key naming in STE and Fangorn vaults
-        #[arg(long, default_value=None)]
-        index: Option<usize>,
-
-        /// whether to print the mnemonic to the terminal when generating
-        /// an sr25519 key
-        #[arg(short, long, default_value_t = false)]
-        print_mnemonic: bool,
-    },
-    Inspect {
-        /// the keystore directory
-        #[arg(long)]
-        keystore_dir: String,
-
-        #[arg(long, default_value = "vault_password")]
-        vault_pswd: String,
-
-        #[arg(long)]
-        key_name: String,
-
-        /// the password to access the associated file
-        #[arg(long)]
-        key_password: SecretString,
-        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
-        #[arg(value_enum)]
-        store_type: StoreType,
-        /// Index used for key naming in STE and Fangorn vaults
-        #[arg(long, default_value=None)]
-        index: Option<usize>,
-    },
-    Sign {
-        /// the keystore directory
-        #[arg(long)]
-        keystore_dir: String,
-
-        #[arg(long, default_value = "vault_password")]
-        vault_pswd: String,
-
-        #[arg(long)]
-        key_name: String,
-
-        #[arg(long)]
-        key_password: SecretString,
-        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
-        #[arg(value_enum)]
-        store_type: StoreType,
-        /// a nonce to sign
-        #[arg(long)]
-        nonce: u32,
-        /// Index used for key naming in STE and Fangorn vaults
-        #[arg(long, default_value=None)]
-        index: Option<usize>,
-    },
-    Verify {
-        /// the keystore directory
-        #[arg(long)]
-        keystore_dir: String,
-        #[arg(long, default_value = "vault_password")]
-        vault_pswd: String,
-
-        #[arg(long)]
-        key_name: String,
-
-        /// the password to access the associated file
-        #[arg(long)]
-        key_password: SecretString,
-        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
-        #[arg(value_enum)]
-        store_type: StoreType,
-        /// the hex printed when using sign-pswd
-        #[arg(long)]
-        signature_hex: String,
-        /// the nonce that was signed when using sign-pswd
-        #[arg(long)]
-        nonce: u32,
-        /// Index used for key naming in STE and Fangorn vaults
-        #[arg(long, default_value=None)]
-        index: Option<usize>,
-    },
     /// encrypt a message under a 'policy' and then 'register' it
     Encrypt {
         /// the path to the plaintext
@@ -229,149 +116,6 @@ async fn main() -> Result<()> {
     let args = Cli::parse();
 
     match &args.command {
-        Some(Commands::Keygen {
-            keystore_dir,
-            key_name,
-            vault_pswd,
-            key_password,
-            store_type,
-            index,
-            print_mnemonic,
-        }) => {
-            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
-            let vault = Vault::open_or_create(keystore_dir, &mut vault_password).unwrap();
-            match store_type {
-                StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
-                    // create sr25519 identity
-                    if *print_mnemonic {
-                        let public_key = keyvault
-                            .generate_key_print_mnemonic()
-                            .unwrap();
-                        println!(
-                            "Printned mnemonic and generated new keypair. PubKey: {:?}",
-                            public_key
-                        );
-                    } else {
-                        let public_key = keyvault
-                            .generate_key()
-                            .unwrap();
-                        println!("generated new keypair. PubKey: {:?}", public_key);
-                    }
-                }
-                StoreType::Fangorn => {
-                    // create ed25519 identity
-                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
-                    let public_key = keyvault
-                        .generate_key()
-                        .unwrap();
-                    println!("generated new keypair. Pubkey: {:?}", public_key)
-                }
-            }
-        }
-        Some(Commands::Inspect {
-            keystore_dir,
-            vault_pswd,
-            key_name,
-            key_password,
-            store_type,
-            index,
-        }) => {
-            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
-            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
-            match store_type {
-                StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
-                    let public_key = keyvault
-                        .get_public_key()
-                        .unwrap();
-                    println!("read keypair. Pubkey: {:?}", public_key)
-                }
-                StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
-                    let public_key = keyvault
-                        .get_public_key()
-                        .unwrap();
-                    println!("read keypair. Pubkey: {:?}", public_key)
-                }
-            }
-        }
-        Some(Commands::Sign {
-            keystore_dir,
-            vault_pswd,
-            key_name,
-            key_password,
-            store_type,
-            index,
-            nonce,
-        }) => {
-            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
-            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
-            match store_type {
-                StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
-                    let message_bytes = nonce.to_le_bytes();
-                    let signature = keyvault
-                        .sign(&message_bytes)
-                        .unwrap();
-                    let sig_hex = to_hex(&signature.as_bytes_ref(), false);
-                    println!(
-                        "Produced a signature on the nonce {:?}: {:?}",
-                        nonce, sig_hex
-                    );
-                }
-                StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
-                    let message_bytes = nonce.to_le_bytes();
-                    let signature = keyvault
-                        .sign(&message_bytes)
-                        .unwrap();
-                    let sig_hex = to_hex(&signature.to_bytes(), false);
-                    println!(
-                        "Produced a signature on the nonce {:?}: {:?}",
-                        nonce, sig_hex
-                    );
-                }
-            }
-        }
-        Some(Commands::Verify {
-            keystore_dir,
-            vault_pswd,
-            key_name,
-            key_password,
-            store_type,
-            signature_hex,
-            index,
-            nonce,
-        }) => {
-            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
-            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
-            match store_type {
-                StoreType::Polkadot => {
-                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
-                    let public_key = keyvault
-                        .get_public_key()
-                        .unwrap();
-                    let message_bytes = nonce.to_le_bytes();
-                    let sig_vec = from_hex(&signature_hex).unwrap();
-                    let sig = SrSignature::from_slice(sig_vec.as_slice()).unwrap();
-                    let result = Sr25519KeyVault::verify(&public_key, &message_bytes, &sig);
-                    println!("Was sig verified: {:?}", result);
-                }
-                StoreType::Fangorn => {
-                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
-                    let public_key = keyvault
-                        .get_public_key()
-                        .unwrap();
-                    let message_bytes = nonce.to_le_bytes();
-                    let sig_vec = from_hex(&signature_hex).unwrap();
-                    let sig_bytes: [u8; 64] = sig_vec.try_into().unwrap();
-                    let sig = iroh::Signature::from_bytes(&sig_bytes);
-                    let result = IrohKeyVault::verify(&public_key, &message_bytes, &sig);
-                    println!("Was sig verified: {:?}", result);
-                }
-            }
-        }
         Some(Commands::Encrypt {
             message_path,
             filename,

--- a/roots/Cargo.toml
+++ b/roots/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "roots"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+ark-serialize.workspace = true
+clap.workspace = true
+fangorn.workspace = true
+tokio.workspace = true
+sp-core.workspace = true
+secrecy.workspace = true
+iroh.workspace = true
+ark-std.workspace = true
+rust-vault.workspace = true
+ed25519 = "2.2.3"
+flume.workspace = true
+silent-threshold-encryption.workspace = true
+n0-future.workspace = true

--- a/roots/README.md
+++ b/roots/README.md
@@ -1,0 +1,56 @@
+# Roots
+
+`roots` is a command-line interface tool built using **Rust** and the **Fangorn** library it provides utilities for key management and cryptographic signing.
+
+-----
+
+## Features
+
+  * **Key Management:** Generate and inspect SR25519 and ED255129 cryptographic keys stored in a local keystore.
+  * **Cryptographic Signing:** Sign arbitrary data (currently a nonce) using a key from the local keystore.
+
+-----
+
+## 🛠️ Usage
+
+The application is structured around several subcommands. Use `--help` on the main command or any subcommand for detailed usage information.
+
+### Installation
+
+1.  Ensure you have **Rust** and **Cargo** installed.
+2.  Clone the repository and build the project:
+
+<!-- end list -->
+
+```bash
+git clone <repository-url>
+cd roots
+cargo build --release
+# The executable will be available at target/release/roots
+```
+
+### Key Management Commands
+
+##### Generate a new keypair
+``` sh
+./target/debug/roots keygen --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD> --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --print-mnemonic
+```
+Note: Index is only required when generating Fangorn keys and print-mnemonic is only used for sr25519 keys. Fangorn keys will be overwritten if pointing to the same vault and if they use the same naming scheme used by Fangorn on startup.
+
+#### Inspect keys
+
+``` sh
+./target/debug/roots inspect --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX>
+```
+
+#### Sign a Message (nonce)
+
+``` sh
+./target/debug/roots sign --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --index <INDEX> --nonce <NONCE>
+```
+
+#### Verify a Signature (nonce)
+
+``` sh
+./target/debug/roots verify --keystore-dir <KEYSTORE_DIRECTORY> --vault-pswd <VAULT_PASSWORD>  --key-name <KEY_NAME> --key-password <KEY_PASSWORD> --signature-hex <SIGNATURE_HEX> --index <INDEX> --nonce <NONCE>
+```

--- a/roots/src/main.rs
+++ b/roots/src/main.rs
@@ -1,0 +1,288 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand, ValueEnum};
+use fangorn::{
+    crypto::{
+        keyvault::{IrohKeyVault, KeyVault, Sr25519KeyVault},
+    },
+};
+use rust_vault::Vault;
+use secrecy::SecretString;
+use sp_core::{
+    ByteArray,
+    bytes::{from_hex, to_hex},
+    hexdisplay::AsBytesRef,
+    sr25519::Signature as SrSignature,
+};
+
+#[derive(Parser, Debug)]
+#[command(name = "roots", version = "1.0")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum StoreType {
+    Polkadot,
+    Fangorn,
+}
+
+/// Define available subcommands
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Keygen {
+        /// the keystore directory
+        #[arg(long)]
+        keystore_dir: String,
+
+        #[arg(long)]
+        key_name: String,
+
+        #[arg(long, default_value = "vault_password")]
+        vault_pswd: String,
+
+        /// the password to encrypt the key with
+        #[arg(long)]
+        key_password: SecretString,
+
+        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
+        #[arg(value_enum)]
+        store_type: StoreType,
+
+        /// Index used for key naming in STE and Fangorn vaults
+        #[arg(long, default_value=None)]
+        index: Option<usize>,
+
+        /// whether to print the mnemonic to the terminal when generating
+        /// an sr25519 key
+        #[arg(short, long, default_value_t = false)]
+        print_mnemonic: bool,
+    },
+    Inspect {
+        /// the keystore directory
+        #[arg(long)]
+        keystore_dir: String,
+
+        #[arg(long, default_value = "vault_password")]
+        vault_pswd: String,
+
+        #[arg(long)]
+        key_name: String,
+
+        /// the password to access the associated file
+        #[arg(long)]
+        key_password: SecretString,
+        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
+        #[arg(value_enum)]
+        store_type: StoreType,
+        /// Index used for key naming in STE and Fangorn vaults
+        #[arg(long, default_value=None)]
+        index: Option<usize>,
+    },
+    Sign {
+        /// the keystore directory
+        #[arg(long)]
+        keystore_dir: String,
+
+        #[arg(long, default_value = "vault_password")]
+        vault_pswd: String,
+
+        #[arg(long)]
+        key_name: String,
+
+        #[arg(long)]
+        key_password: SecretString,
+        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
+        #[arg(value_enum)]
+        store_type: StoreType,
+        /// a nonce to sign
+        #[arg(long)]
+        nonce: u32,
+        /// Index used for key naming in STE and Fangorn vaults
+        #[arg(long, default_value=None)]
+        index: Option<usize>,
+    },
+    Verify {
+        /// the keystore directory
+        #[arg(long)]
+        keystore_dir: String,
+        #[arg(long, default_value = "vault_password")]
+        vault_pswd: String,
+
+        #[arg(long)]
+        key_name: String,
+
+        /// the password to access the associated file
+        #[arg(long)]
+        key_password: SecretString,
+        /// the associated key type: polkadot(sr25519), fangorn(ed25519)
+        #[arg(value_enum)]
+        store_type: StoreType,
+        /// the hex printed when using sign-pswd
+        #[arg(long)]
+        signature_hex: String,
+        /// the nonce that was signed when using sign-pswd
+        #[arg(long)]
+        nonce: u32,
+        /// Index used for key naming in STE and Fangorn vaults
+        #[arg(long, default_value=None)]
+        index: Option<usize>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Cli::parse();
+
+    match &args.command {
+        Some(Commands::Keygen {
+            keystore_dir,
+            key_name,
+            vault_pswd,
+            key_password,
+            store_type,
+            index,
+            print_mnemonic,
+        }) => {
+            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
+            let vault = Vault::open_or_create(keystore_dir, &mut vault_password).unwrap();
+            match store_type {
+                StoreType::Polkadot => {
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
+                    // create sr25519 identity
+                    if *print_mnemonic {
+                        let public_key = keyvault
+                            .generate_key_print_mnemonic()
+                            .unwrap();
+                        println!(
+                            "Printned mnemonic and generated new keypair. PubKey: {:?}",
+                            public_key
+                        );
+                    } else {
+                        let public_key = keyvault
+                            .generate_key()
+                            .unwrap();
+                        println!("generated new keypair. PubKey: {:?}", public_key);
+                    }
+                }
+                StoreType::Fangorn => {
+                    // create ed25519 identity
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
+                    let public_key = keyvault
+                        .generate_key()
+                        .unwrap();
+                    println!("generated new keypair. Pubkey: {:?}", public_key)
+                }
+            }
+        }
+        Some(Commands::Inspect {
+            keystore_dir,
+            vault_pswd,
+            key_name,
+            key_password,
+            store_type,
+            index,
+        }) => {
+            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
+            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
+            match store_type {
+                StoreType::Polkadot => {
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
+                    let public_key = keyvault
+                        .get_public_key()
+                        .unwrap();
+                    println!("read keypair. Pubkey: {:?}", public_key)
+                }
+                StoreType::Fangorn => {
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
+                    let public_key = keyvault
+                        .get_public_key()
+                        .unwrap();
+                    println!("read keypair. Pubkey: {:?}", public_key)
+                }
+            }
+        }
+        Some(Commands::Sign {
+            keystore_dir,
+            vault_pswd,
+            key_name,
+            key_password,
+            store_type,
+            index,
+            nonce,
+        }) => {
+            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
+            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
+            match store_type {
+                StoreType::Polkadot => {
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
+                    let message_bytes = nonce.to_le_bytes();
+                    let signature = keyvault
+                        .sign(&message_bytes)
+                        .unwrap();
+                    let sig_hex = to_hex(&signature.as_bytes_ref(), false);
+                    println!(
+                        "Produced a signature on the nonce {:?}: {:?}",
+                        nonce, sig_hex
+                    );
+                }
+                StoreType::Fangorn => {
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
+                    let message_bytes = nonce.to_le_bytes();
+                    let signature = keyvault
+                        .sign(&message_bytes)
+                        .unwrap();
+                    let sig_hex = to_hex(&signature.to_bytes(), false);
+                    println!(
+                        "Produced a signature on the nonce {:?}: {:?}",
+                        nonce, sig_hex
+                    );
+                }
+            }
+        }
+        Some(Commands::Verify {
+            keystore_dir,
+            vault_pswd,
+            key_name,
+            key_password,
+            store_type,
+            signature_hex,
+            index,
+            nonce,
+        }) => {
+            let mut vault_password = SecretString::new(vault_pswd.to_owned().into_boxed_str());
+            let vault = Vault::open(keystore_dir, &mut vault_password).unwrap();
+            match store_type {
+                StoreType::Polkadot => {
+                    let keyvault = Sr25519KeyVault::new_store_info(vault, vault_password, key_name.clone(), key_password.clone());
+                    let public_key = keyvault
+                        .get_public_key()
+                        .unwrap();
+                    let message_bytes = nonce.to_le_bytes();
+                    let sig_vec = from_hex(&signature_hex).unwrap();
+                    let sig = SrSignature::from_slice(sig_vec.as_slice()).unwrap();
+                    let result = Sr25519KeyVault::verify(&public_key, &message_bytes, &sig);
+                    println!("Was sig verified: {:?}", result);
+                }
+                StoreType::Fangorn => {
+                    let keyvault = IrohKeyVault::new_store_info(vault, vault_password, key_password.clone(), index.unwrap_or(0));
+                    let public_key = keyvault
+                        .get_public_key()
+                        .unwrap();
+                    let message_bytes = nonce.to_le_bytes();
+                    let sig_vec = from_hex(&signature_hex).unwrap();
+                    let sig_bytes: [u8; 64] = sig_vec.try_into().unwrap();
+                    let sig = iroh::Signature::from_bytes(&sig_bytes);
+                    let result = IrohKeyVault::verify(&public_key, &message_bytes, &sig);
+                    println!("Was sig verified: {:?}", result);
+                }
+            }
+        }
+        None => {
+            // do nothing
+        }
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
In this PR, I've re-factored the keyvaults. They are now more self contained and do not require filenames or passwords to be passed when performing actions. Key related CLI functionality has been moved into "roots". 